### PR TITLE
Remove text crossed out in the google doc

### DIFF
--- a/contrib/index.rst
+++ b/contrib/index.rst
@@ -41,16 +41,15 @@ Proposed Contents
         * Standard for communication
         * Enforcement details
     * Roles
-        * Core teamdevelopers (from devguide)
-        * (SC?) (EB?)
+        * Core team (from devguide)
         * Triager
         * Contributors
-            * types of contributions, role of each contributors
+            * types of contributions
     * Governance
         * (SC?) (EB?)
         * Other WG? Typing council? C-API WG?
     * GitHub
-        * Main CPython rRepos
+        * Main CPython repos
         * Core workflow repos
         * Infrastructure repos
     * Communication channels
@@ -67,7 +66,6 @@ Proposed Contents
     * (Reviewing)
         * How? Etiquette?
         * How to request a review?
-    * Where to get help
 * Getting started
     * Basic setup
     * Git bootcamp (simplified for everyone to use)
@@ -89,6 +87,6 @@ Proposed Contents
     * Need details
 * Accessibility and user success
 * Security and infrastructure
-    * Core Team Resources (from the devguide
+    * Core Team Resources (from the devguide)
 * Outreach
     * Sprints

--- a/contrib/project.rst
+++ b/contrib/project.rst
@@ -14,16 +14,15 @@ The CPython project
     * Standard for communication
     * Enforcement details
 * Roles
-    * Core teamdevelopers (from devguide)
-    * (SC?) (EB?)
+    * Core team (from devguide)
     * Triager
     * Contributors
-        * types of contributions, role of each contributors
+        * types of contributions
 * Governance
     * (SC?) (EB?)
     * Other WG? Typing council? C-API WG?
 * GitHub
-    * Main CPython rRepos
+    * Main CPython repos
     * Core workflow repos
     * Infrastructure repos
 * Communication channels
@@ -40,4 +39,3 @@ The CPython project
 * (Reviewing)
     * How? Etiquette?
     * How to request a review?
-* Where to get help


### PR DESCRIPTION
The crossed-out text in the Google doc was carried over into the .rst.  This removes them.


<!-- readthedocs-preview cpython-devguide start -->
----
📚 Documentation preview 📚: https://cpython-devguide--1.org.readthedocs.build/

<!-- readthedocs-preview cpython-devguide end -->